### PR TITLE
Scripts for splitting nanoAOD scans into individual samples

### DIFF
--- a/test/haddnano.py
+++ b/test/haddnano.py
@@ -1,0 +1,77 @@
+#!/bin/env python
+import ROOT
+from array import array
+import sys
+
+if len(sys.argv) < 3 :
+	print "Syntax: haddnano.py out.root input1.root input2.root ..."
+ofname=sys.argv[1]
+files=sys.argv[2:]
+
+def zeroFill(tree,brName,brObj) :
+	if brObj.GetLeaf(brName).GetTypeName() != "Bool_t" :
+		print "Did not expect to back fill non-boolean branches",tree,brName,brObj.GetLeaf(br).GetTypeName()
+	else :
+		buff=array('B',[0])
+		b=tree.Branch(brName,buff,brName+"/O")
+	        b.SetBasketSize(tree.GetEntries()*2) #be sure we do not trigger flushing
+		for x in xrange(0,tree.GetEntries()):	
+			b.Fill()
+		b.ResetAddress()
+fileHandles=[]
+goFast=True
+for fn in files :
+    print "Adding file",fn
+    fileHandles.append(ROOT.TFile.Open(fn))
+    if fileHandles[-1].GetCompressionSettings() != fileHandles[0].GetCompressionSettings() :
+	goFast=False
+	print "Disabling fast merging as inputs have different compressions"
+of=ROOT.TFile(ofname,"recreate")
+if goFast :
+	of.SetCompressionSettings(fileHandles[0].GetCompressionSettings())
+of.cd()
+
+for e in fileHandles[0].GetListOfKeys() :
+	name=e.GetName()
+	print "Merging" ,name
+	obj=e.ReadObj()
+	cl=ROOT.TClass.GetClass(e.GetClassName())
+	inputs=ROOT.TList()
+	isTree= obj.IsA().InheritsFrom(ROOT.TTree.Class())
+	if isTree :
+		obj=obj.CloneTree(-1,"fast" if goFast else "")
+		branchNames=set([x.GetName() for x in obj.GetListOfBranches()])
+	for fh in fileHandles[1:] :
+		otherObj=fh.GetListOfKeys().FindObject(name).ReadObj()
+		inputs.Add(otherObj)
+		if isTree and obj.GetName()=='Events'  :	
+			otherObj.SetAutoFlush(0)
+			otherBranches=set([ x.GetName() for x in otherObj.GetListOfBranches() ])
+			missingBranches=list(branchNames-otherBranches)
+			additionalBranches=list(otherBranches-branchNames)
+			print "missing:",missingBranches,"\n Additional:",additionalBranches
+			for br in missingBranches :
+				#fill "Other"	
+				zeroFill(otherObj,br,obj.GetListOfBranches().FindObject(br))
+			for br in additionalBranches :
+				#fill main	
+				branchNames.add(br)
+				zeroFill(obj,br,otherObj.GetListOfBranches().FindObject(br))
+			#merge immediately for trees
+                if isTree:
+	        	obj.Merge(inputs,"fast" if goFast else "")
+			inputs.Clear()
+	
+        if isTree  :
+		obj.Write()	
+	elif obj.IsA().InheritsFrom(ROOT.TH1.Class()) :		
+		obj.Merge(inputs)
+		obj.Write()
+	elif obj.IsA().InheritsFrom(ROOT.TObjString.Class()) :	
+		for st in inputs:
+		 	if  st.GetString()!=obj.GetString():
+				print "Strings are not matching"
+		obj.Write()
+	else:
+		print "Cannot handle ", obj.IsA().GetName()
+	

--- a/test/haddnano.py
+++ b/test/haddnano.py
@@ -49,7 +49,7 @@ for e in fileHandles[0].GetListOfKeys() :
 			otherBranches=set([ x.GetName() for x in otherObj.GetListOfBranches() ])
 			missingBranches=list(branchNames-otherBranches)
 			additionalBranches=list(otherBranches-branchNames)
-			print "missing:",missingBranches,"\n Additional:",additionalBranches
+			#print "missing:",missingBranches,"\n Additional:",additionalBranches
 			for br in missingBranches :
 				#fill "Other"	
 				zeroFill(otherObj,br,obj.GetListOfBranches().FindObject(br))

--- a/test/splitTrees.py
+++ b/test/splitTrees.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+import ROOT
+import os
+
+def splitfile(inputs):
+    fname, options = inputs[0], inputs[1]
+    allpoints={}
+    if not os.path.exists(options.output):
+      os.system("mkdir -p "+options.output)
+    f = ROOT.TFile.Open(fname,'read')
+    t = f.Events
+    print('Total events in %s: %d'%(fname,t.GetEntries()))
+
+    # First we keep nothing
+    t.SetBranchStatus('*',0) # Speed up by only using useful branches
+    # split using GenModel information
+    t.SetBranchStatus('GenModel*',1) # Speed up by only using useful branches
+    list_branches = [key.GetName() for key in t.GetListOfBranches()]
+    for l in list_branches:
+      if "GenModel" in l:
+        name = l.replace("GenModel_","")
+        allpoints[name] = ROOT.TEventList(name, name)
+
+    # Now we fill up the TEventList
+    for nev in xrange(t.GetEntries()):
+      if nev%10000==1: print('Gen-Scanning event %d/%d'%(nev, t.GetEntries()))
+      t.GetEntry(nev)
+      for key in allpoints.keys():
+        if getattr(t, "GenModel_"+key):
+          allpoints[key].Enter(nev)
+
+    for m in sorted(allpoints.keys()): 
+      print('-------%s: %d events'%(m,allpoints[m].GetN()))
+
+    # Now we reactivate all branches so we save the whole tree!
+    t.SetBranchStatus("*",1)
+    for drop in options.drop: t.SetBranchStatus(drop,0) # Except thos we don't want
+    for keep in options.keep: t.SetBranchStatus(keep,1) # Just in case we want to do some regexp with the previous step
+
+    # The actual saving
+    for m,elist in allpoints.iteritems():
+      output = options.output + "/" + fname.split("/")[-1].replace(".root", "_" + m + ".root")
+      if os.path.exists(output): raise RuntimeError, 'Output file already exists'
+      fout = ROOT.TFile(output,'recreate')
+      fout.cd()
+      t.SetEventList(elist)
+      out = t.CopyTree('1')
+      fout.WriteTObject(out,'Events')
+      fout.Close()
+    return allpoints.keys()
+
+def haddfiles(inputs):
+    outdir = inputs[0]
+    name   = inputs[1]
+    os.system("python haddnano.py %s/%s_merged.root %s/*%s*root"%(outdir, name,outdir, name))
+
+if __name__ == "__main__":
+    from optparse import OptionParser
+    parser = OptionParser(usage="%prog [options] outputDir inputDirs")
+    parser.add_option("-D", "--drop",  dest="drop", type="string", default=["GenModel_*"], action="append",  help="Branches to drop, as per TTree::SetBranchStatus. Default is to just drop the 'GenModel' ones.") 
+    parser.add_option("-K", "--keep",  dest="keep", type="string", default=[], action="append",  help="Branches to keep, as per TTree::SetBranchStatus. Default is all, but can we used to reactive after kdrop.") 
+    parser.add_option("--input", dest="input", type="string" , default=None, help="Input folder containing the .root files needed for the splitting")
+    parser.add_option("--output"  , dest="output", type="string", default=None, help="Output folder containing the .root files after the splitting")
+    parser.add_option("--jobs"  , dest="jobs", type="int", default=1, help="How many cores to take (default = 1, sequential running).")
+    parser.add_option("--hadd"  , dest="hadd", action="store_true", default=False, help="If activated, run hadd over split chunks to get merged .root files.")
+
+    (options, args) = parser.parse_args()
+    
+    allInputFiles = []
+    for f in os.listdir(options.input):
+      if not("root" in f): continue
+      allInputFiles.append(options.input+ "/" + f)
+    print("Will write selected trees to "+options.output)
+    allpoints = []
+    if options.jobs == 1:
+      for f in allInputFiles:
+        allpoints += splitfile([f, options])
+    else:
+      allInputs = [[f,options] for f in allInputFiles]
+      from multiprocessing import Pool
+      from contextlib import closing
+      import time
+      with closing(Pool(options.jobs)) as p:
+        retlist1 = p.map_async(splitfile, allInputs, 1)
+        while not retlist1.ready():
+          time.sleep(0.001)
+        retlist1 = retlist1.get()
+        p.close()
+        p.join()
+        p.terminate()
+      for r in retlist1:
+        allpoints += r
+    allpoints = list(dict.fromkeys(allpoints))
+    if options.hadd:
+      print("Will now hadd the splitted chunks")
+      if options.jobs == 1:
+        for p in allpoints:
+          haddfiles([options.output, p])
+      else:
+        allInputs = [[options.output, p] for p in allpoints]
+        with closing(Pool(options.jobs)) as p:
+          retlist1 = p.map_async(haddfiles, allInputs, 1)
+          while not retlist1.ready():
+            time.sleep(0.001)
+          retlist1 = retlist1.get()
+          p.close()
+          p.join()
+          p.terminate()


### PR DESCRIPTION
[splitTrees.py](https://github.com/cericeci/SUEPNano/blob/ul/test/splitTrees.py) can be used to split a set of input nanoAOD samples based on the correponding gen-level setup and -optionally- merge the resulting chunks together (i.e. same signal point coming from different nanosuep files). Usage is:

`python splitTrees.py --input [input directory] --output [output directory] --jobs [number of cores] --hadd 
` 

[haddnano.py](https://github.com/cericeci/SUEPNano/blob/ul/test/haddnano.py) is just a modified version of the standard cms-sw tool to reduce verbosity a bit 